### PR TITLE
Add route.bible as an optional link destination

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -135,6 +135,12 @@ const dynamicFunctionVersion = 'dfv_';
 const dynamicFunctionSource  = 'dfs_';
 var dynamicMenuGenerateDone = false;
 
+Object.keys(BIBLE_DATA_SOURCES).forEach((key) => {
+  if ( Array.isArray(BIBLE_DATA_SOURCES[key].bibleVersions) ) {
+    BIBLE_DATA_SOURCES[key].bibleVersions = ensureRouteBibleVersionList(BIBLE_DATA_SOURCES[key].bibleVersions);
+  };
+});
+
 //////////////////
 // Dynamic menu //
 //////////////////
@@ -752,19 +758,25 @@ function getUrl(bibleData, bibleVersion, bookNum, chapterStart, verseStart, vers
     verseEnd = verseEnd.padStart(targetLength, padString);
   };
 
+  if ( bibleVersion === ROUTE_BIBLE_VERSION ) {
+    let referenceText = buildRouteBibleReference(bookNameFull, chapterStart, verseStart, verseEnd, chapterEnd);
+    return buildRouteBibleUrl(referenceText);
+  };
+
   // Get URL format for replacement
   let url = bibleData.bibleVersions[bibleVersion].urlFormat;
 
   // Replace strings to format final URL
-  url = url
-    .replace(/<<bookNum>>/g, bookNum)
-    .replace(/<<chapterStart>>/g, chapterStart)
-    .replace(/<<verseStart>>/g, verseStart)
-    .replace(/<<verseEnd>>/g, verseEnd)
-    .replace(/<<chapterEnd>>/g, chapterEnd)
-    .replace(/<bookNameAbbr1>>/g, bookNameAbbr1)
-    .replace(/<<bookNameAbbr2>>/g, bookNameAbbr2)
-    .replace(/<<bookNameFull>>/g, bookNameFull);
+  url = applyUrlFormat(url, {
+    bookNum,
+    chapterStart,
+    verseStart,
+    verseEnd,
+    chapterEnd,
+    bookNameAbbr1,
+    bookNameAbbr2,
+    bookNameFull
+  });
 
   // Remove range in URL if single verse scripture only
   if ( chapterStart === chapterEnd && verseStart === verseEnd ) url = url.replace(/-[0-9]+$|-[0-9]+:[0-9]+:[0-9]+$/, '');
@@ -825,7 +837,7 @@ function getBibleData(bibleDataSourceUrl, bibleDataSource) {
         // Return and exit if valid JSON
         try {
 
-          bibleDataJSON = JSON.parse(bibleData.getContentText());
+          bibleDataJSON = withRouteBibleDestination(JSON.parse(bibleData.getContentText()));
 
           return bibleDataJSON;
 
@@ -870,7 +882,7 @@ function getBibleData(bibleDataSourceUrl, bibleDataSource) {
     // Return and exit if valid JSON
     try {
 
-      bibleDataJSON = JSON.parse(bibleData.getContentText());
+      bibleDataJSON = withRouteBibleDestination(JSON.parse(bibleData.getContentText()));
 
       return bibleDataJSON;
     

--- a/README.md
+++ b/README.md
@@ -29,5 +29,7 @@ Coders are welcome to improve the script. It's open source. MIT license.
 For samples of [valid JSON](https://www.google.com/search?q=json+validator) files, see the [bible-data](bible-data) directory.  
 Testing of new JSON files can be done via the menu **Extensions > Bible Linker > Choose language (data source) > Set custom data source ...**
 
+To send detected references to Route Bible, choose **Route Bible** from the Bible version menu. Bible Linker keeps its current default destination unchanged and creates links such as `https://route.bible/?q=John%203%3A16&utm_source=google_docs_linker&utm_medium=link`.
+
 ## Other copyrights
 The Bibles and languages initially supported came from [versions listed in jw.org](https://www.jw.org/en/library/bible/) and [Watchtower Online Library](https://wol.jw.org/en/wol/binav/r1/lp-e). The [Terms of Use](https://www.jw.org/finder?prefer=content&wtlocale=E&docid=1011511) of these websites do not allow the sharing of their contents. However, it allows [linking to these websites](https://www.jw.org/finder?prefer=content&wtlocale=E&docid=1011511&par=21-23), which is what this script does.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Coders are welcome to improve the script. It's open source. MIT license.
 For samples of [valid JSON](https://www.google.com/search?q=json+validator) files, see the [bible-data](bible-data) directory.  
 Testing of new JSON files can be done via the menu **Extensions > Bible Linker > Choose language (data source) > Set custom data source ...**
 
-To send detected references to Route Bible, choose **Route Bible** from the Bible version menu. Bible Linker keeps its current default destination unchanged and creates links such as `https://route.bible/?q=John%203%3A16&utm_source=google_docs_linker&utm_medium=link`.
+To send detected references to route.bible, choose **route.bible** from the Bible version menu. Bible Linker keeps its current default destination unchanged and creates links such as `https://route.bible/?q=John%203%3A16&utm_source=google_docs_linker&utm_medium=link`.
 
 ## Other copyrights
 The Bibles and languages initially supported came from [versions listed in jw.org](https://www.jw.org/en/library/bible/) and [Watchtower Online Library](https://wol.jw.org/en/wol/binav/r1/lp-e). The [Terms of Use](https://www.jw.org/finder?prefer=content&wtlocale=E&docid=1011511) of these websites do not allow the sharing of their contents. However, it allows [linking to these websites](https://www.jw.org/finder?prefer=content&wtlocale=E&docid=1011511&par=21-23), which is what this script does.

--- a/RouteBible.js
+++ b/RouteBible.js
@@ -1,0 +1,74 @@
+const ROUTE_BIBLE_VERSION = "route_bible";
+const ROUTE_BIBLE_DISPLAY_NAME = "Route Bible";
+
+function ensureRouteBibleVersionList(bibleVersions) {
+  const versions = Array.isArray(bibleVersions) ? bibleVersions.slice() : [];
+
+  if (!versions.includes(ROUTE_BIBLE_VERSION)) {
+    versions.push(ROUTE_BIBLE_VERSION);
+  }
+
+  return versions;
+}
+
+function withRouteBibleDestination(bibleData) {
+  if (!bibleData || !bibleData.bibleVersions) return bibleData;
+
+  bibleData.bibleVersions[ROUTE_BIBLE_VERSION] = {
+    displayName: ROUTE_BIBLE_DISPLAY_NAME,
+    padStart: {},
+    urlFormat: ""
+  };
+
+  return bibleData;
+}
+
+function buildRouteBibleReference(bookName, chapterStart, verseStart, verseEnd, chapterEnd) {
+  const start = `${chapterStart}:${verseStart}`;
+  const hasChapterRange = Boolean(chapterEnd) && Number(chapterEnd) !== Number(chapterStart);
+  const hasVerseRange = Boolean(verseEnd) && Number(verseEnd) !== Number(verseStart);
+
+  let end = "";
+
+  if (hasChapterRange) {
+    end = `${chapterEnd}:${verseEnd}`;
+  } else if (hasVerseRange) {
+    end = `${verseEnd}`;
+  }
+
+  return `${bookName} ${end ? `${start}-${end}` : start}`.trim();
+}
+
+function buildRouteBibleUrl(referenceText, translation) {
+  let url = `https://route.bible/?q=${encodeURIComponent(referenceText)}&utm_source=google_docs_linker&utm_medium=link`;
+
+  if (translation) {
+    url += `&v=${encodeURIComponent(translation)}`;
+  }
+
+  return url;
+}
+
+function applyUrlFormat(urlFormat, values) {
+  return urlFormat
+    .replace(/<<bookNum>>/g, values.bookNum)
+    .replace(/<<chapterStart>>/g, values.chapterStart)
+    .replace(/<<verseStart>>/g, values.verseStart)
+    .replace(/<<verseEnd>>/g, values.verseEnd)
+    .replace(/<<chapterEnd>>/g, values.chapterEnd)
+    .replace(/<bookNameAbbr1>>/g, values.bookNameAbbr1)
+    .replace(/<<bookNameAbbr2>>/g, values.bookNameAbbr2)
+    .replace(/<<bookNameFull>>/g, values.bookNameFull);
+}
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    ROUTE_BIBLE_DISPLAY_NAME,
+    ROUTE_BIBLE_VERSION,
+    applyUrlFormat,
+    buildRouteBibleReference,
+    buildRouteBibleUrl,
+    ensureRouteBibleVersionList,
+    withRouteBibleDestination
+  };
+}

--- a/RouteBible.js
+++ b/RouteBible.js
@@ -1,5 +1,5 @@
 const ROUTE_BIBLE_VERSION = "route_bible";
-const ROUTE_BIBLE_DISPLAY_NAME = "Route Bible";
+const ROUTE_BIBLE_DISPLAY_NAME = "route.bible";
 
 function ensureRouteBibleVersionList(bibleVersions) {
   const versions = Array.isArray(bibleVersions) ? bibleVersions.slice() : [];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bible-linker-google-docs",
+  "private": true,
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  }
+}

--- a/tests/route-bible.test.js
+++ b/tests/route-bible.test.js
@@ -1,0 +1,48 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  ROUTE_BIBLE_VERSION,
+  applyUrlFormat,
+  buildRouteBibleReference,
+  buildRouteBibleUrl,
+  ensureRouteBibleVersionList
+} = require("../RouteBible.js");
+
+test("Route Bible destination produces the expected URL", () => {
+  const reference = buildRouteBibleReference("John", 3, 16, 16, 3);
+  const url = buildRouteBibleUrl(reference);
+
+  assert.equal(reference, "John 3:16");
+  assert.equal(
+    url,
+    "https://route.bible/?q=John%203%3A16&utm_source=google_docs_linker&utm_medium=link"
+  );
+});
+
+test("Route Bible destination is added to the supported versions list", () => {
+  assert.deepEqual(
+    ensureRouteBibleVersionList(["en_jw_nwt"]),
+    ["en_jw_nwt", ROUTE_BIBLE_VERSION]
+  );
+});
+
+test("Existing JW.org URL formatting remains unchanged", () => {
+  const url = applyUrlFormat(
+    "https://www.jw.org/finder?wtlocale=E&pub=nwt&bible=<<bookNum>><<chapterStart>><<verseStart>>-<<bookNum>><<chapterEnd>><<verseEnd>>",
+    {
+      bookNum: "43",
+      chapterStart: "003",
+      verseStart: "016",
+      verseEnd: "016",
+      chapterEnd: "003",
+      bookNameAbbr1: "Joh",
+      bookNameAbbr2: "John",
+      bookNameFull: "John"
+    }
+  );
+
+  assert.equal(
+    url,
+    "https://www.jw.org/finder?wtlocale=E&pub=nwt&bible=43003016-43003016"
+  );
+});

--- a/tests/route-bible.test.js
+++ b/tests/route-bible.test.js
@@ -8,7 +8,7 @@ const {
   ensureRouteBibleVersionList
 } = require("../RouteBible.js");
 
-test("Route Bible destination produces the expected URL", () => {
+test("route.bible destination produces the expected URL", () => {
   const reference = buildRouteBibleReference("John", 3, 16, 16, 3);
   const url = buildRouteBibleUrl(reference);
 
@@ -19,7 +19,7 @@ test("Route Bible destination produces the expected URL", () => {
   );
 });
 
-test("Route Bible destination is added to the supported versions list", () => {
+test("route.bible destination is added to the supported versions list", () => {
   assert.deepEqual(
     ensureRouteBibleVersionList(["en_jw_nwt"]),
     ["en_jw_nwt", ROUTE_BIBLE_VERSION]


### PR DESCRIPTION
## Summary
- adds route.bible as an optional output in the existing Bible version menu
- preserves the current default destination and existing JW.org URL behavior
- adds a small helper/test file and README note

## Details
- exposes `route.bible` without changing the current default selection
- builds outbound links as `https://route.bible/?q=<reference>&utm_source=google_docs_linker&utm_medium=link`
- keeps the existing reference detection/parser flow intact

Note: this repo does not currently have a separate destination picker abstraction, so the optional route.bible destination is surfaced through the existing version-selection path.

## Validation
- `npm test`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required because this change only normalizes user-visible route.bible branding copy in docs, display text, and test descriptions.
